### PR TITLE
Allow for es6 style consumption of repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "geocoder-js",
   "version": "0.0.0",
+  "main": "./src/GeocoderJS.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.6",


### PR DESCRIPTION
```
  import geocoderJS from 'geocoder-js';
```
