### PR TITLE
Allow for es6 style consumption of repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geocoder-js",
-  "main": "./dist/geocoder.js",
+  "main": "./dist/geocoder.min.js",
   "version": "0.0.0",
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "geocoder-js",
+  "main": "./dist/GeocoderJS.js",
   "version": "0.0.0",
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geocoder-js",
-  "main": "./dist/GeocoderJS.js",
+  "main": "./dist/geocoder.js",
   "version": "0.0.0",
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
```
  import geocoderJS from 'geocoder-js';
```
