### PR TITLE
Fall back to window if exports isnt an option

### DIFF
--- a/src/GeocoderJS.js
+++ b/src/GeocoderJS.js
@@ -9,7 +9,7 @@
       return factory.createProvider(options);
     };
 
-    var container = (typeof window === "object") ? window : (typeof exports === "object") ? exports : {};
+    var container = (typeof exports === "object") ? exports : (typeof window === "object") ? window : {};
     container.GeocoderJS = GeocoderJS;
 })();
 


### PR DESCRIPTION
If we are checking that window exists before looking for a loader system, we wind up unable to really use this well with frameworks like webpack. It's a shame too, because there aren't many other working implementations of an isomorphic.js geolocation module.

Example:

Before:

```
import geocoderJS from 'geocoder-js';
console.log(geocoderJS); // {}
```

After:

```
import geocoderJS from 'geocoder-js';
console.log(geocoderJS); // { GeocoderJS: { version: '0.0.0', createGeocoder: [Function] } }
```
